### PR TITLE
Thoughts for a parser

### DIFF
--- a/tex.js
+++ b/tex.js
@@ -36,7 +36,15 @@ syntaxes = {
     integral: {
         re: /\\int\^\{(.*)\}_\{(.*)\} (.*)/,
         template: "<div integral><div upperbound>{}</div><div lowerbound>{}</div><div of>{}</div></div>"
-    }
+    },
+    summation: {
+        re: /\\sum\^\{(.*)\}_\{(.*)\} (.*)/,
+        template: "<div summation><div upperbound>{}</div><div lowerbound>{}</div><div of>{}</div></div>"
+    },
+    fraction: {
+        re: /\\frac\{(.*)\}\{(.*)\}/,
+        template: "<div fraction><div top>{}</div><div bottom>{}</div></div>"
+    },
 }
 
 function interpolate(str, args) {
@@ -48,7 +56,7 @@ function interpolate(str, args) {
 compile = function(str) {
     for (var key in syntaxes) {
         var match = str.match(syntaxes[key].re);
-        if (match.length > 0) {
+        if (match && match.length) {
             return interpolate(syntaxes[key].template, match.slice(1))
         }
     }

--- a/tex.js
+++ b/tex.js
@@ -1,0 +1,55 @@
+/*
+
+Take in format like:
+
+\operator^{upper}_{lower} content
+
+And convert to:
+
+<div operator>
+    <div upperbound>
+        upper
+    </div>
+    <div lowerbound>
+        lower
+    </div>
+    <div of>
+        content
+    </div>
+</div>
+*/
+
+
+// This is some very basic parsing. We should be doing smarter stuff than this,
+// but it's just a proof of concept for now.
+
+str = "\\int^{1}_{0} i dx"
+operators = {
+    'int': 'integral'
+}
+
+symbols = {
+    'pi': '<hr pi>'
+}
+
+syntaxes = {
+    integral: {
+        re: /\\int\^\{(.*)\}_\{(.*)\} (.*)/,
+        template: "<div integral><div upperbound>{}</div><div lowerbound>{}</div><div of>{}</div></div>"
+    }
+}
+
+function interpolate(str, args) {
+    var regex = /\{\}/;
+    var _r=function(p,c){return p.replace(regex,c);}
+    return args.reduce(_r, str);
+}
+
+compile = function(str) {
+    for (var key in syntaxes) {
+        var match = str.match(syntaxes[key].re);
+        if (match.length > 0) {
+            return interpolate(syntaxes[key].template, match.slice(1))
+        }
+    }
+}


### PR DESCRIPTION
Alright. So this is overzealous, absolutely. But I'd love to have a super-basic parser that can convert something like `\int^{x}_{y} dt` to the correct HTML to be used in your markup. 

As my proof of concept, try running the `compile()` function on a string like `str = "\\int^{1}_{0} i dx"`. It returns the minified HTML,

```
<div integral><div upperbound>1</div><div lowerbound>0</div><div of>i dx</div></div>
```

If anyone is interested in talking about how better to implement a grammar, I'd love to chat. This is certainly not the right strategy, but I really really want "realtime" "TeX" "rendering" (note the heavy use of quotes) when I'm playing around in markdown or something.
